### PR TITLE
Adding Raspberry Pi 3 to list of ARM7 builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To make a developers live even easier, we're providing in the [release section](
 all pre-compiled Go tarballs for all supported ARM versions:
 - ARMv5
 - ARMv6 (Raspberry Pi A, A+, B, B+, Zero)
-- ARMv7 (Raspberry Pi 2, Scaleway C1)
+- ARMv7 (Raspberry Pi 2, 3, Scaleway C1)
 - ARM64 (which is also known as AARCH64)
 
 


### PR DESCRIPTION
Though the pi 3's CPU is actually ARMv8, it runs 32-bit binaries and behaves like an ARMv7 machine:

model name      : ARMv7 Processor rev 4 (v7l)

This is hardly the primary place that confusion should be cleared up, but I got tripped up trying to find an arm64 build that would run on my pi, or trying to make one myself, when for instance the official ARMv6 distribution works fine.

Just thought adding this little 3 here might save someone else some wasted time.
